### PR TITLE
食材検索後の遷移ミスを修正

### DIFF
--- a/app/views/foods/_index.html.erb
+++ b/app/views/foods/_index.html.erb
@@ -1,6 +1,6 @@
 <h3 class="text-center">食材一覧</h3>
-<%= search_form_for @q, url: new_brand_path do |f| %>
-  <%= f.search_field :name_cont, placeholder: "業態名を入力" %>
+<%= search_form_for @q, url: new_food_path do |f| %>
+  <%= f.search_field :name_cont, placeholder: "食材名を入力" %>
   <%= f.submit "検索"%>
 <% end %>
 


### PR DESCRIPTION
## 概要
- 遷移先の指定ミスを修正
### 内容
- 食材検索語の遷移先が業態になっていたので修正
- placeholderが間違っていたので修正