### PR TITLE
レシピの分量(amount)の型を変更

### DIFF
--- a/app/models/food_recipe.rb
+++ b/app/models/food_recipe.rb
@@ -1,6 +1,6 @@
 class FoodRecipe < ApplicationRecord
   belongs_to :food
   belongs_to :recipe
-  validates :amount, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :amount, presence: true, numericality: {greater_than: 0 }
   validates :food_id, uniqueness: { scope: :recipe_id }
 end

--- a/app/views/recipes/_food_recipe_fields.html.erb
+++ b/app/views/recipes/_food_recipe_fields.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="field form-group col">
       <% f.label :amount %>
-      <%= f.text_field :amount, placeholder: "分量を入力", class: "form-control valid-field" %>
+      <%= f.number_field :amount,step: '0.01', placeholder: "分量を入力", class: "form-control valid-field" %>
       <div class="invalid-feedback">入力して下さい</div>
     </div>
     <div class="cocoon__deleate col">

--- a/db/migrate/20210102134921_change_datatype_amount_of_food_recipes.rb
+++ b/db/migrate/20210102134921_change_datatype_amount_of_food_recipes.rb
@@ -1,0 +1,4 @@
+class ChangeDatatypeAmountOfFoodRecipes < ActiveRecord::Migration[6.0]
+  def change
+  end
+end

--- a/db/migrate/20210102134921_change_datatype_amount_of_food_recipes.rb
+++ b/db/migrate/20210102134921_change_datatype_amount_of_food_recipes.rb
@@ -1,4 +1,5 @@
 class ChangeDatatypeAmountOfFoodRecipes < ActiveRecord::Migration[6.0]
   def change
+    change_column :food_recipes, :amount, :float
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_18_135450) do
+ActiveRecord::Schema.define(version: 2021_01_02_134921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2020_10_18_135450) do
   create_table "food_recipes", force: :cascade do |t|
     t.bigint "food_id", null: false
     t.bigint "recipe_id", null: false
-    t.integer "amount", null: false
+    t.float "amount", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["food_id", "recipe_id"], name: "index_food_recipes_on_food_id_and_recipe_id", unique: true


### PR DESCRIPTION
## 概要
- 分量の入力に柔軟性を持たせるために整数型から浮動小数点型に変更
### 内容
- 型変更のためのマイグレーションファイルの作成
- 入力フォームをtext_fieldからnumber_fieldを変更
- food_recipeモデルの整数縛りを解除